### PR TITLE
fix: add type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tailwindcss-plugin-starter",
+  "name": "twglow",
   "version": "0.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "tailwindcss-plugin-starter",
+      "name": "twglow",
       "version": "0.0.10",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.10",
   "description": "A tailwind css plugin for making your elements glow",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "type": "module",
   "files": [
     "src/"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,7 @@
+declare function plugin(): { handler: () => void }
+
+declare namespace plugin {
+  const __isOptionsFunction: false
+}
+
+export default plugin


### PR DESCRIPTION
This adds type definitions to the plugin, so TypeScript won't complain about missing declarations when the plugin is imported.

PS: Thank you for the project. I really like it so far. ^^